### PR TITLE
Fix artifact manual upload queue status

### DIFF
--- a/backend/app/app/api/api_v1/endpoints/orders.py
+++ b/backend/app/app/api/api_v1/endpoints/orders.py
@@ -279,10 +279,11 @@ def submit_artifact(
             status_code=403,
             detail="Buyer's Numerai API Key does not have permission to upload submissions",
         )
-    if order.submit_state == "queued":
-        raise HTTPException(
-            status_code=400, detail="Submission for this order is already queued"
-        )
+    # Disable queue check to always redo queuing
+    # if order.submit_state == "queued":
+    #     raise HTTPException(
+    #         status_code=400, detail="Submission for this order is already queued"
+    #     )
 
     active_round = crud.globals.get_singleton(db=db).active_round  # type: ignore
 

--- a/backend/app/app/worker.py
+++ b/backend/app/app/worker.py
@@ -530,9 +530,10 @@ def upload_numerai_artifact_task(  # pylint: disable=too-many-arguments
         if not order:
             print(f"Order {order_id} not found, skipped")
             return None
-        if order.submit_state == "queued":  # already queued for submission
-            print(f"Order {order.id} already queued for submission, skipped")
-            return None
+        # Disable queue check to always redo submission
+        # if order.submit_state == "queued":  # already queued for submission
+        #     print(f"Order {order.id} already queued for submission, skipped")
+        #     return None
         crud.order.update(db, db_obj=order, obj_in={"submit_state": "queued"})
     finally:
         db.close()
@@ -788,11 +789,12 @@ def validate_artifact_upload_task(  # pylint: disable=too-many-branches
             for order in orders:
                 if not order.submit_model_id:
                     continue
-                if (
-                    order.submit_state == "queued"
-                ):  # already queued for submission, skip
-                    print(f"Order {order.id} already queued for submission, skipped")
-                    continue
+                # Disable queue check to always redo queuing
+                # if (
+                #     order.submit_state == "queued"
+                # ):  # already queued for submission, skip
+                #     print(f"Order {order.id} already queued for submission, skipped")
+                #     continue
 
                 print(
                     f"Uploading csv artifact {artifact.object_name} for order {order.id}"

--- a/frontend/packages/theme/components/section/ArtifactModal.vue
+++ b/frontend/packages/theme/components/section/ArtifactModal.vue
@@ -25,7 +25,10 @@
 <!--                    <td></td>-->
                     <td>
                       <div class="d-flex justify-content-between" v-if="Boolean(artifact) && !!artifact.object_name && !!order.submit_model_id">
-                        <button class="icon-btn ms-auto" title="Submit to Numerai" @click="submit(artifact)"><em class="ni ni-upload-cloud"></em></button>
+                        <button class="icon-btn ms-auto" title="Submit to Numerai" @click="submit(artifact)">
+                          <span class="spinner-border spinner-border-sm" role="status" v-if="loading"></span>
+                          <em class="ni ni-upload-cloud" v-else></em>
+                        </button>
                       </div>
                     </td>
                 </tr>
@@ -252,6 +255,12 @@ export default {
           message: this.error.submitArtifact.message,
           type: 'bg-danger',
           icon: 'ni-alert-circle'
+        });
+      } else {
+        this.send({
+          message: 'Submission queued, please wait for a minute',
+          type: 'bg-success',
+          icon: 'ni-check'
         });
       }
     }


### PR DESCRIPTION
Disable artifact manual submission queue status check such that an attempt will always be made, also adds notification for successful queuing. Fixes #29